### PR TITLE
Adding firefox needed for selenium tests.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 MAINTAINER Zostera B.V.
-LABEL version="0.3.0"
+LABEL version="0.3.1"
 # Based on work by Janusz Skonieczny @wooyek
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -20,11 +20,12 @@ RUN apt-get install -y git unzip wget sudo curl build-essential gettext \
 RUN curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash - && \
     apt-get -y install nodejs
 
-# install geckodriver needed for selenium tests
+# install firefox and geckodriver needed for selenium tests
 RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz && \
     tar -xvzf geckodriver-v0.24.0-linux64.tar.gz && \
     mv geckodriver /usr/local/bin && \
-    rm -f geckodriver-v0.24.0-linux64.tar.gz
+    rm -f geckodriver-v0.24.0-linux64.tar.gz && \
+    sudo apt-get -y install firefox
 
 RUN python -m pip install pip -U && \
     apt-get -y clean && \


### PR DESCRIPTION
For running selenium test with headless firefox we need to install firefox. Something I overlooked in the previous pull request.