### PR TITLE
Adds redis server to the django ci docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,9 @@ RUN apt-get install -y git unzip wget sudo curl build-essential gettext \
 RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash - && \
     apt-get -y install nodejs libxcb-dri3-0 libxss1 libdrm2 libgbm1
 
-# install the redis server
-RUN apt-get -y install redis-server
+# install the redis server, bind to ipv4 (or it will not start)
+RUN apt-get -y install redis-server && \
+    sed -i "s/^bind 127.0.0.1.*/bind 127.0.0.1/g" /etc/redis/redis.conf
 
 # install firefox and geckodriver needed for selenium tests
 RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN apt-get install -y git unzip wget sudo curl build-essential gettext \
 RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash - && \
     apt-get -y install nodejs libxcb-dri3-0 libxss1 libdrm2 libgbm1
 
+# install the redis server
+RUN apt-get -y install redis-server
+
 # install firefox and geckodriver needed for selenium tests
 RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz && \
     tar -xvzf geckodriver-v0.24.0-linux64.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic-20200219
 
 MAINTAINER Zostera B.V.
-LABEL version="0.3.3"
+LABEL version="0.3.4"
 # Based on work by Janusz Skonieczny @wooyek
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/django-entrypoint.sh
+++ b/django-entrypoint.sh
@@ -6,6 +6,11 @@
 /etc/init.d/memcached start
 
 # =========================
+# Start redis service
+# =========================
+/etc/init.d/redis-server start
+
+# =========================
 # Setup Postgres data base
 # =========================
 /etc/init.d/postgresql start


### PR DESCRIPTION
This configures the redis server in this docker image needed for cache testing in the observation code.
